### PR TITLE
Prevent exceeding max UMAs on frontend, fix icon and avatars from shrinking

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.2",
+    "@radix-ui/react-tooltip": "^1.1.6",
     "@radix-ui/react-visually-hidden": "^1.1.1",
     "@simplewebauthn/browser": "^13.0.0-alpha1",
     "class-variance-authority": "^0.7.0",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -76,6 +76,16 @@ body {
   }
 }
 
+@layer utilities {
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+  .no-scrollbar {
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+  }
+}
+
 @layer base {
   * {
     @apply border-border;

--- a/frontend/src/components/SandboxAvatar.tsx
+++ b/frontend/src/components/SandboxAvatar.tsx
@@ -82,6 +82,7 @@ export const SandboxAvatar = (props: Props) => {
           boxShadow: props.shadow ? "0px 1px 1px rgba(0, 0, 0, 0.25)" : "",
           width: `${getWidthHeight(size)}px`,
           height: `${getWidthHeight(size)}px`,
+          minWidth: `${getWidthHeight(size)}px`,
           fontSize: `${getFontSize(size)}px`,
           lineHeight: `${getLineHeight(size)}px`,
         }}
@@ -101,6 +102,7 @@ export const SandboxAvatar = (props: Props) => {
           boxShadow: props.shadow ? "0px 1px 1px rgba(0, 0, 0, 0.25)" : "",
           width: `${getWidthHeight(size)}px`,
           height: `${getWidthHeight(size)}px`,
+          minWidth: `${getWidthHeight(size)}px`,
           fontSize: `${getFontSize(size)}px`,
           lineHeight: `${getLineHeight(size)}px`,
         }}
@@ -118,6 +120,7 @@ export const SandboxAvatar = (props: Props) => {
           boxShadow: props.shadow ? "0px 1px 1px rgba(0, 0, 0, 0.25)" : "",
           width: `${getWidthHeight(size)}px`,
           height: `${getWidthHeight(size)}px`,
+          minWidth: `${getWidthHeight(size)}px`,
           fontSize: `${getFontSize(size)}px`,
           lineHeight: `${getLineHeight(size)}px`,
         }}
@@ -143,6 +146,7 @@ export const SandboxAvatar = (props: Props) => {
         boxShadow: props.shadow ? "0px 1px 1px rgba(0, 0, 0, 0.25)" : "",
         width: `${getWidthHeight(size)}px`,
         height: `${getWidthHeight(size)}px`,
+        minWidth: `${getWidthHeight(size)}px`,
       }}
     >
       <AvatarImage src={avatarSrc} />

--- a/frontend/src/components/SandboxButton.tsx
+++ b/frontend/src/components/SandboxButton.tsx
@@ -5,12 +5,19 @@ import { cva } from "class-variance-authority";
 import { Loader2 } from "lucide-react";
 import { useState } from "react";
 import { Button, ButtonProps } from "./ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
 
 interface Props {
   loading?: boolean;
   disabled?: boolean;
   buttonProps?: ButtonProps;
   className?: string;
+  tooltip?: string | undefined;
   children: React.ReactNode;
 }
 
@@ -25,7 +32,7 @@ export const SandboxButton = (props: Props) => {
     setIsPressed(false);
   };
 
-  return (
+  const button = (
     <Button
       {...props.buttonProps}
       disabled={props.disabled || props.loading}
@@ -48,5 +55,16 @@ export const SandboxButton = (props: Props) => {
       {props.loading && <Loader2 className="animate-spin" />}
       {props.children}
     </Button>
+  );
+
+  return props.tooltip ? (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent>{props.tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  ) : (
+    button
   );
 };

--- a/frontend/src/components/UmaSwitcherFooter.tsx
+++ b/frontend/src/components/UmaSwitcherFooter.tsx
@@ -25,6 +25,8 @@ import {
   DrawerTitle,
 } from "./ui/drawer";
 
+const MAX_WALLETS = 10;
+
 const WalletRows = ({
   currentWallet,
   wallets,
@@ -116,7 +118,15 @@ export const UmaSwitcherFooter = ({ wallets, refreshWallets }: Props) => {
   const [isCreatingUma, setIsCreatingUma] = useState(false);
 
   const handleCreateUma = () => {
-    setIsCreatingUma(true);
+    const hasMaxWallets = wallets.length >= MAX_WALLETS;
+    if (hasMaxWallets) {
+      toast({
+        title:
+          "You have reached the maximum number of test UMAs for this account",
+      });
+    } else {
+      setIsCreatingUma(true);
+    }
   };
 
   const handleChooseWallet = (wallet: Wallet) => {
@@ -132,7 +142,7 @@ export const UmaSwitcherFooter = ({ wallets, refreshWallets }: Props) => {
           key={wallet.id}
           className={`
             animate-[fadeInAndSlideUp_0.5s_ease-in-out_forwards]
-            transition-transform active:scale-95 duration-100
+            transition-transform active:scale-95 duration-100 cursor-pointer
             ${
               wallet.id === currentWallet.id
                 ? "ring-1 ring-offset-8 ring-[#C0C9D6] rounded-xl"
@@ -153,15 +163,23 @@ export const UmaSwitcherFooter = ({ wallets, refreshWallets }: Props) => {
   }
 
   return (
-    <div className="flex flex-row p-4 w-full items-center justify-center gap-4">
+    <div className="flex flex-row p-4 w-full items-center justify-start overflow-x-scroll no-scrollbar gap-4">
       {walletButtons}
       {currentWallet && wallets && (
-        <Drawer open={isDrawerOpen}>
+        <Drawer open={isDrawerOpen} onClose={() => setIsDrawerOpen(false)}>
           <Button
             className="p-2 bg-[#EBEEF2] hover:bg-gray-300 h-8 w-8 rounded-lg"
             onClick={() => setIsDrawerOpen(true)}
+            size="icon"
+            variant="icon"
           >
-            <Image src="/icons/plus.svg" alt="Add UMA" width={24} height={24} />
+            <Image
+              src="/icons/plus.svg"
+              alt="Add UMA"
+              width={24}
+              height={24}
+              className="max-w-6"
+            />
           </Button>
           <DrawerContent className="w-full">
             {isCreatingUma ? (
@@ -215,6 +233,8 @@ const UmaSelectorDrawerContent = ({
     router.push("/settings");
   };
 
+  const hasMaxWallets = wallets.length >= MAX_WALLETS;
+
   return (
     <>
       <DrawerHeader className="">
@@ -245,6 +265,11 @@ const UmaSelectorDrawerContent = ({
             size: "lg",
             onClick: handleCreateUma,
           }}
+          tooltip={
+            hasMaxWallets
+              ? "You have reached the maximum number of test UMAs for this account"
+              : undefined
+          }
           className="w-full gap-2 items-center justify-center"
         >
           <Image

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -49,7 +49,9 @@ const DrawerContent = React.forwardRef<
       {...props}
     >
       <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
-      <div className="max-h-screen overflow-y-scroll">{children}</div>
+      <div className="max-h-screen overflow-y-scroll no-scrollbar">
+        {children}
+      </div>
     </DrawerPrimitive.Content>
   </DrawerPortal>
 ));

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-[100] overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    {...props}
+  />
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -354,6 +354,13 @@
   dependencies:
     "@radix-ui/react-primitive" "2.0.0"
 
+"@radix-ui/react-arrow@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.1.tgz#2103721933a8bfc6e53bbfbdc1aaad5fc8ba0dd7"
+  integrity sha512-NaVpZfmv8SKeZbn4ijN2V3jlHA9ngBG16VnIIm22nUR0Yk8KUALyBxT3KYEUnNuch9sTE8UTsS3whzBgKOL30w==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.1"
+
 "@radix-ui/react-avatar@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-avatar/-/react-avatar-1.1.1.tgz#5848d2ed5f34d18b36fc7e2d227c41fca8600ea1"
@@ -531,6 +538,22 @@
     "@radix-ui/react-use-size" "1.1.0"
     "@radix-ui/rect" "1.1.0"
 
+"@radix-ui/react-popper@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.2.1.tgz#2fc66cfc34f95f00d858924e3bee54beae2dff0a"
+  integrity sha512-3kn5Me69L+jv82EKRuQCXdYyf1DqHwD2U/sxoNgBGCB7K9TRc3bQamQ+5EPM9EvyPdli0W41sROd+ZU1dTCztw==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+    "@radix-ui/react-use-rect" "1.1.0"
+    "@radix-ui/react-use-size" "1.1.0"
+    "@radix-ui/rect" "1.1.0"
+
 "@radix-ui/react-portal@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.2.tgz#51eb46dae7505074b306ebcb985bf65cc547d74e"
@@ -624,6 +647,24 @@
     "@radix-ui/react-use-layout-effect" "1.1.0"
     "@radix-ui/react-visually-hidden" "1.1.0"
 
+"@radix-ui/react-tooltip@^1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.1.6.tgz#eab98e9a5c876ef0abfae3cfeee229870528ed06"
+  integrity sha512-TLB5D8QLExS1uDn7+wH/bjEmRurNMTzNrtq7IjaS4kjion9NtzsTGkvR5+i7yc9q01Pi2KMM2cN3f8UG4IvvXA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-dismissable-layer" "1.1.3"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-popper" "1.2.1"
+    "@radix-ui/react-portal" "1.1.3"
+    "@radix-ui/react-presence" "1.1.2"
+    "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-slot" "1.1.1"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    "@radix-ui/react-visually-hidden" "1.1.1"
+
 "@radix-ui/react-use-callback-ref@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz#bce938ca413675bc937944b0d01ef6f4a6dc5bf1"
@@ -669,7 +710,7 @@
   dependencies:
     "@radix-ui/react-primitive" "2.0.0"
 
-"@radix-ui/react-visually-hidden@^1.1.1":
+"@radix-ui/react-visually-hidden@1.1.1", "@radix-ui/react-visually-hidden@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.1.tgz#f7b48c1af50dfdc366e92726aee6d591996c5752"
   integrity sha512-vVfA2IZ9q/J+gEamvj761Oq1FpWgCDaNOOIfbPVp2MVPLEomUr5+Vf7kJGwQ24YxZSlQVar7Bes8kyTo5Dshpg==


### PR DESCRIPTION
- adds frontend check for max wallets (so the user doesn't just see an error)
- shows tooltip on button (for some reason radix doesn't seem to allow showing tooltips on disabled buttons)
- shows notification upon pressing button
- makes wallets in footer scrollable
- the add icon was shrinking due to global css setting max-width
- the sandbox avatars need min-width to avoid shrinking as well
- drawer was not closing due to not using the onClose prop in Drawer

![Screenshot 2024-12-20 at 1.20.41 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/fdfc0eef-6e00-4397-b239-0364b88a0e85.png)

