### PR TITLE
Get UMA Auth working with login redirects

### DIFF
--- a/backend/vasp/uma.py
+++ b/backend/vasp/uma.py
@@ -153,7 +153,7 @@ def create_uma() -> Response:
 
 
 @bp.get("/<uma_user_name>")
-async def uma(uma_user_name: str) -> Response:
+def uma(uma_user_name: str) -> Response:
     with Session(db.engine) as db_session:
         uma_model = db_session.scalars(
             select(UmaModel).where(UmaModel.username == uma_user_name)
@@ -162,8 +162,8 @@ async def uma(uma_user_name: str) -> Response:
 
 
 @bp.get("/generate_random_uma")
-async def generate_random_uma() -> Response:
-    random_uma = await _generate_random_uma()
+def generate_random_uma() -> Response:
+    random_uma = _generate_random_uma()
     return (
         jsonify({"uma": random_uma})
         if random_uma
@@ -171,9 +171,7 @@ async def generate_random_uma() -> Response:
     )
 
 
-async def _generate_random_uma(
-    batch_size: int = 100, max_attempts: int = 100
-) -> str | None:
+def _generate_random_uma(batch_size: int = 100, max_attempts: int = 100) -> str | None:
     attempts = 0
 
     while attempts < max_attempts:
@@ -181,14 +179,14 @@ async def _generate_random_uma(
             f"{random.choice(APPROVED_ADJECTIVES).lower()}-{random.choice(APPROVED_NOUNS).lower()}-{random.randint(0, 999):03d}"
             for _ in range(batch_size)
         )
-        available_set = await _available_umas_in_set(generated_usernames)
+        available_set = _available_umas_in_set(generated_usernames)
         if available_set:
             return random.choice(list(available_set))
         attempts += 1
     return None
 
 
-async def _available_umas_in_set(umaSet: set[str]) -> set[str]:
+def _available_umas_in_set(umaSet: set[str]) -> set[str]:
     with Session(db.engine) as db_session:
         existing_uma = db_session.scalars(
             select(UmaModel).where(UmaModel.username.in_(umaSet))

--- a/backend/vasp/uma_vasp/receiving_vasp.py
+++ b/backend/vasp/uma_vasp/receiving_vasp.py
@@ -187,7 +187,7 @@ class ReceivingVasp:
             uma_version=None,
         )
 
-    async def handle_pay_request_callback(self, username: str) -> Dict[str, Any]:
+    def handle_pay_request_callback(self, username: str) -> Dict[str, Any]:
         user = self.user_service.get_user_from_uma(username)
         if not user:
             raise UmaException(
@@ -362,7 +362,7 @@ class ReceivingVasp:
             payee_data=None,
         )
 
-    async def handle_create_uma_invoice(self, user_id: str) -> str:
+    def handle_create_uma_invoice(self, user_id: str) -> str:
         user = self.user_service.get_user_from_id(user_id)
         if not user:
             raise UmaException(
@@ -380,7 +380,7 @@ class ReceivingVasp:
                     status_code=404,
                 )
 
-        flask_request_data = await flask_request.json
+        flask_request_data = flask_request.json
         amount = flask_request_data.get("amount")
 
         currency_code = flask_request_data.get("currency_code")
@@ -433,7 +433,7 @@ class ReceivingVasp:
         )
         return invoice.to_bech32_string()
 
-    async def create_and_send_invoice(self, user_id: str) -> Response:
+    def create_and_send_invoice(self, user_id: str) -> Response:
         user = self.user_service.get_user_from_id(user_id)
         if not user:
             raise UmaException(
@@ -450,8 +450,8 @@ class ReceivingVasp:
                     status_code=404,
                 )
 
-        flask_request_data = await flask_request.json
-        amount = await flask_request_data.get("amount")
+        flask_request_data = flask_request.json
+        amount = flask_request_data.get("amount")
 
         currency_code = flask_request_data.get("currency_code")
         if not currency_code:
@@ -592,30 +592,30 @@ def register_routes(
         return receiving_vasp.handle_lnurlp_request(username)
 
     @app.post(PAY_REQUEST_CALLBACK + "<username>")
-    async def handle_uma_pay_request_callback(username: str) -> Dict[str, Any]:
+    def handle_uma_pay_request_callback(username: str) -> Dict[str, Any]:
         receiving_vasp = get_receiving_vasp()
-        return await receiving_vasp.handle_pay_request_callback(username)
+        return receiving_vasp.handle_pay_request_callback(username)
 
     @app.get(PAY_REQUEST_CALLBACK + "<username>")
     @login_required
-    async def handle_lnurl_pay_request_callback(username: str) -> Dict[str, Any]:
+    def handle_lnurl_pay_request_callback(username: str) -> Dict[str, Any]:
         receiving_vasp = get_receiving_vasp()
-        return await receiving_vasp.handle_pay_request_callback(username)
+        return receiving_vasp.handle_pay_request_callback(username)
 
     @app.post("/api/uma/create_invoice")
     @login_required
-    async def handle_create_uma_invoice() -> str:
+    def handle_create_uma_invoice() -> str:
         receiving_vasp = get_receiving_vasp()
-        return await receiving_vasp.handle_create_uma_invoice(current_user.id)
+        return receiving_vasp.handle_create_uma_invoice(current_user.id)
 
     @app.post("/api/uma/create_and_send_invoice")
     @login_required
-    async def handle_create_and_send_invoice() -> Response:
+    def handle_create_and_send_invoice() -> Response:
         receiving_vasp = get_receiving_vasp()
-        return await receiving_vasp.create_and_send_invoice(current_user.id)
+        return receiving_vasp.create_and_send_invoice(current_user.id)
 
     @app.post("/webhooks/transaction")
-    async def handle_post_transaction() -> Response:
+    def handle_post_transaction() -> Response:
         signature_header = flask_request.headers.get(webhooks.SIGNATURE_HEADER)
         if not signature_header:
             abort_with_error(400, "Missing signature header")

--- a/backend/vasp/user.py
+++ b/backend/vasp/user.py
@@ -156,7 +156,7 @@ def construct_blueprint(
 
     @bp.route("/avatar", methods=["GET", "POST"])
     @login_required
-    async def avatar() -> Response:
+    def avatar() -> Response:
         with Session(db.engine) as db_session:
             user_model = db_session.scalars(
                 select(UserModel).where(UserModel.id == current_user.id)
@@ -183,7 +183,7 @@ def construct_blueprint(
 
     @bp.route("/full-name", methods=["GET", "POST"])
     @login_required
-    async def full_name() -> Response:
+    def full_name() -> Response:
         with Session(db.engine) as db_session:
             user_model = db_session.scalars(
                 select(UserModel).where(UserModel.id == current_user.id)
@@ -203,7 +203,7 @@ def construct_blueprint(
 
     @bp.post("/device-token")
     @login_required
-    async def device_token() -> Response:
+    def device_token() -> Response:
         with Session(db.engine) as db_session:
             wallet = db_session.scalars(
                 select(Wallet).where(Wallet.user_id == current_user.id)
@@ -336,7 +336,7 @@ def construct_blueprint(
 
     @bp.route("/preferences", methods=["POST", "GET"])
     @login_required
-    async def preferences() -> Response:
+    def preferences() -> Response:
         with Session(db.engine) as db_session:
             preferences = db_session.scalars(
                 select(Preference).where(Preference.user_id == current_user.id)
@@ -387,7 +387,7 @@ def construct_blueprint(
 
     @bp.get("/currencies")
     @login_required
-    async def currencies() -> Response:
+    def currencies() -> Response:
         user_id = current_user.id
 
         with Session(db.engine) as db_session:
@@ -402,7 +402,7 @@ def construct_blueprint(
 
     @bp.get("/login_methods")
     @login_required
-    async def login_methods() -> Response:
+    def login_methods() -> Response:
         with Session(db.engine) as db_session:
             webauthn_credentials = db_session.scalars(
                 select(WebAuthnCredential).where(

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { SandboxButton } from "@/components/SandboxButton";
+import { useToast } from "@/hooks/use-toast";
+import { getBackendUrl } from "@/lib/backendUrl";
+import { convertArrayBuffersToBase64 } from "@/lib/convertArrayBuffersToBase64";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export default function Page() {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [isLoadingLogin, setIsLoadingLogin] = useState(false);
+
+  const handleLogin = async () => {
+    setIsLoadingLogin(true);
+
+    try {
+      const prepRes = await fetch(
+        `${getBackendUrl()}/auth/webauthn_prepare_login`,
+        {
+          method: "POST",
+        },
+      );
+      const prepData = (await prepRes.json()) as {
+        challenge_id: string;
+        options: {
+          allowCredentials: [];
+          challenge: string;
+          rpId: string;
+          timeout: number;
+        };
+      };
+
+      const credential = await navigator.credentials.get({
+        publicKey: {
+          ...prepData.options,
+          challenge: Uint8Array.from(prepData.options.challenge, (c) =>
+            c.charCodeAt(0),
+          ),
+        },
+      });
+      if (!credential) {
+        toast({
+          title: "Login method not provided.",
+          variant: "error",
+        });
+        setIsLoadingLogin(false);
+        return;
+      }
+
+      const loginRes = await fetch(`${getBackendUrl()}/auth/login`, {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          webauthn: {
+            challenge_id: prepData.challenge_id,
+            credential: convertArrayBuffersToBase64(
+              credential as unknown as Record<string, string | ArrayBuffer>,
+            ),
+          },
+        }),
+      });
+      const loginData = await loginRes.json();
+      if (loginData.success) {
+        // Get redirect uri from next query param
+        const next = new URLSearchParams(window.location.search).get("next");
+        const [path, redirectUri] = next?.split("?redirect_uri=") || [];
+
+        if (!path || !redirectUri) {
+          toast({
+            title: "Failed to redirect.",
+            variant: "error",
+          });
+        } else {
+          router.push(
+            `${getBackendUrl()}${path}?redirect_uri=${encodeURIComponent(
+              redirectUri,
+            )}`,
+          );
+        }
+      } else {
+        toast({
+          title: "Failed to login.",
+          variant: "error",
+        });
+      }
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoadingLogin(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full items-center justify-center">
+      <SandboxButton
+        buttonProps={{
+          size: "lg",
+          onClick: handleLogin,
+        }}
+        loading={isLoadingLogin}
+        className="w-full"
+      >
+        Login
+      </SandboxButton>
+    </div>
+  );
+}


### PR DESCRIPTION
This gets the UMA Auth oauth flow and nwc requests working; tested with the example app in uma-nwc-server.

- adds uma to session for jwt auth
- loads user from jwt if the user_id exists on the session (from jwt auth)
- adds login redirect for oauth flow
- adds placeholder login UI which redirects to nwc frontend
- fixes budget currency in nwc frontend which was defaulted to SATs
- implements paying with different currencies in pay_to_address
- fixes sender currency not being provided to sending_vasp lookup when calling pay_to_address