### PR TITLE
Get cross-sub-domain cookies working for UMA Auth/playground

### DIFF
--- a/backend/vasp/redirect.py
+++ b/backend/vasp/redirect.py
@@ -1,8 +1,6 @@
-import os
 from flask import redirect
 from werkzeug.wrappers import Response
-
-is_dev: bool = os.environ.get("FLASK_ENV") == "development"
+from vasp.utils import is_dev
 
 
 def redirect_frontend(path: str) -> Response:

--- a/backend/vasp/uma_vasp/sending_vasp.py
+++ b/backend/vasp/uma_vasp/sending_vasp.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import time
 from datetime import datetime
 from typing import Any, Dict, List, Optional
@@ -11,7 +10,7 @@ from lightspark import CurrencyUnit
 from lightspark import LightsparkSyncClient as LightsparkClient
 from lightspark import OutgoingPayment, PaymentDirection, TransactionStatus
 from lightspark.utils.currency_amount import amount_as_msats
-from vasp.utils import get_vasp_domain, is_valid_uma, get_username_from_uma
+from vasp.utils import get_vasp_domain, is_valid_uma, get_username_from_uma, is_dev
 from vasp.uma_vasp.address_helpers import get_domain_from_uma_address
 from vasp.uma_vasp.config import Config
 from vasp.uma_vasp.interfaces.compliance_service import IComplianceService
@@ -105,7 +104,7 @@ class SendingVasp:
             is_subject_to_travel_rule=True,
         )
 
-        if os.environ.get("FLASK_ENV") == "development":
+        if is_dev:
             url = url.replace("https://", "http://")
 
         response = requests.get(url, timeout=20)

--- a/backend/vasp/utils.py
+++ b/backend/vasp/utils.py
@@ -2,6 +2,7 @@ from flask import current_app
 from cryptography.hazmat.primitives.asymmetric import ec
 from OpenSSL import crypto
 from uuid import uuid4
+import os
 
 
 def get_vasp_domain() -> str:
@@ -59,3 +60,13 @@ def get_username_from_uma(uma: str) -> str:
         uma = uma.split("@")[0]
 
     return uma
+
+
+FRONTEND_ALLOWED_ORIGINS = [
+    "http://localhost:3000",
+    "http://localhost:3001",
+    "http://sandbox.localhost:3000",
+    "https://sandbox.uma.me",
+]
+
+is_dev: bool = os.environ.get("FLASK_ENV") == "development"

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -2,15 +2,23 @@
 
 import { SandboxButton } from "@/components/SandboxButton";
 import { useToast } from "@/hooks/use-toast";
+import { useLoggedIn } from "@/hooks/useLoggedIn";
 import { getBackendUrl } from "@/lib/backendUrl";
 import { convertArrayBuffersToBase64 } from "@/lib/convertArrayBuffersToBase64";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function Page() {
   const router = useRouter();
   const { toast } = useToast();
   const [isLoadingLogin, setIsLoadingLogin] = useState(false);
+  const { isLoggedIn } = useLoggedIn();
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      router.push("/wallet");
+    }
+  }, [router, isLoggedIn]);
 
   const handleLogin = async () => {
     setIsLoadingLogin(true);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,7 @@
 "use client";
+import { useLoggedIn } from "@/hooks/useLoggedIn";
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 import OnboardingStepContextProvider, {
   OnboardingStep,
 } from "./(onboarding)/OnboardingStepContextProvider";
@@ -7,6 +9,13 @@ import { Steps } from "./(onboarding)/Steps";
 
 export default function Home() {
   const router = useRouter();
+  const { isLoggedIn } = useLoggedIn();
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      router.push("/wallet");
+    }
+  }, [router, isLoggedIn]);
 
   return (
     <div className="flex flex-col h-full items-center justify-center">

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -49,7 +49,7 @@ const DrawerContent = React.forwardRef<
       {...props}
     >
       <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
-      <div className="flex items-center justify-center max-h-screen overflow-y-scroll no-scrollbar">
+      <div className="flex flex-col justify-center max-h-screen overflow-y-scroll no-scrollbar">
         {children}
       </div>
     </DrawerPrimitive.Content>


### PR DESCRIPTION
We want to create this experience:
- user creates a guest uma on playground.uma.me
- user uma auths with one of the demos
- the uma auth redirect goes to sandbox.uma.me
- the session cookies must be valid still in order to know which uma the user can uma auth with

All that's needed is to set the cookie domain to `.uma.me` (or for testing purposes, `.localhost:3000`). To test this locally just create a /etc/hosts entry with 127.0.0.1 sandbox.localhost

- also adds a couple frontend redirects to /wallet when the user is already logged in
- fixes DrawerContent styling