### PR TITLE
Fix wallet footer centering and scroll, adjust responsive styles

### DIFF
--- a/frontend/src/app/(onboarding)/Steps.tsx
+++ b/frontend/src/app/(onboarding)/Steps.tsx
@@ -23,7 +23,7 @@ export const Step = (props: StepProps) => {
   const { onNext } = useOnboardingStepContext();
 
   return (
-    <div className="flex flex-col h-full gap-8 pt-6 max-w-[400px]">
+    <div className="flex flex-col h-full gap-8 pt-6 min-w-[400px] max-w-[425px]">
       {(props.title || props.description) && (
         <div className="flex flex-col gap-2 px-8">
           {props.title && (

--- a/frontend/src/app/(onboarding)/WalletCustomization.tsx
+++ b/frontend/src/app/(onboarding)/WalletCustomization.tsx
@@ -88,7 +88,7 @@ const OtherCurrencies = ({
           currency. You can always change this later in Settings.
         </DialogDescription>
       </VisuallyHidden.Root>
-      <DialogContent className="sm:max-w-[425px] max-sm:h-full max-h-dvh overflow-scroll justify-start">
+      <DialogContent className="min-w-[400px] max-sm:h-full max-h-dvh overflow-scroll justify-start">
         <div className="flex flex-col gap-2 px-8 pb-3 pt-[68px]">
           <h1 className="text-primary text-[26px] font-normal leading-[34px] tracking-[-0.325px]">
             Select preferred currency

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -63,10 +63,10 @@ export default function RootLayout({
         />
       </head>
       <body
-        className={`${inter.variable} ${roboto_mono.variable} h-dvh flex items-center justify-center sm:bg-[#F9F9F9]`}
+        className={`${inter.variable} ${roboto_mono.variable} h-dvh flex items-center justify-center mobile:bg-[#F9F9F9]`}
       >
         <PushNotificationManager />
-        <div className="max-w-[432px] sm:min-w-[400px] w-full h-dvh max-h-[916px] sm:border-[0.5px] border-[#EBEEF2] sm:rounded-[32px] sm:px-4 sm:pt-6 bg-white">
+        <div className="max-w-[432px] mobile:min-w-[400px] w-full h-dvh max-h-[916px] mobile:border-[0.5px] border-[#EBEEF2] mobile:rounded-[32px] mobile:px-4 mobile:pt-6 bg-white">
           {children}
           <Toaster />
         </div>

--- a/frontend/src/app/wallet/layout.tsx
+++ b/frontend/src/app/wallet/layout.tsx
@@ -169,7 +169,7 @@ const LayoutContent = ({ children }: { children: React.ReactNode }) => {
         {children}
       </main>
       {wallets && wallets.length > 0 && (
-        <div className="pt-2 px-4 pb-3 border-[#EBEEF2] border-t">
+        <div className="pt-2 px-4 pb-3 border-[#EBEEF2] border-t overflow-x-scroll no-scrollbar flex justify-center">
           <UmaSwitcherFooter
             wallets={wallets || []}
             refreshWallets={handleRefreshWallets}

--- a/frontend/src/components/ResponsiveDialog.tsx
+++ b/frontend/src/components/ResponsiveDialog.tsx
@@ -25,7 +25,7 @@ export const ResponsiveDialog = ({
   title,
   description,
 }: Props) => {
-  const isDesktop = useMediaQuery("(min-width: 768px)");
+  const isDesktop = useMediaQuery("(min-width: 480px)");
 
   if (isDesktop) {
     return (

--- a/frontend/src/components/UmaSwitcherFooter.tsx
+++ b/frontend/src/components/UmaSwitcherFooter.tsx
@@ -162,7 +162,7 @@ export const UmaSwitcherFooter = ({ wallets, refreshWallets }: Props) => {
   }
 
   return (
-    <div className="flex flex-row p-4 w-full items-center justify-start overflow-x-scroll no-scrollbar gap-4">
+    <div className="flex flex-row py-4 max-w-full items-center gap-4">
       {walletButtons}
       <Button
         className="p-2 bg-[#EBEEF2] hover:bg-gray-300 h-8 w-8 rounded-lg"
@@ -238,7 +238,7 @@ const UmaSelectorDialogContent = ({
 
   return (
     <>
-      <div className="flex flex-row w-full justify-between items-center px-6 py-2">
+      <div className="flex flex-row w-full justify-between items-center px-6 py-2 min-w-[400px]">
         <span className="text-[26px] font-normal leading-[34px] tracking-[-0.325px]">
           Account
         </span>

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-fit translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-3xl  max-h-screen overflow-y-scroll no-scrollbar",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-fit translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] mobile:rounded-3xl  max-h-screen overflow-y-scroll no-scrollbar",
         className,
       )}
       {...props}

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -62,7 +62,10 @@ const DrawerHeader = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn("grid gap-1.5 pl-6 pr-4 text-center sm:text-left", className)}
+    className={cn(
+      "grid gap-1.5 pl-6 pr-4 text-center mobile:text-left",
+      className,
+    )}
     {...props}
   />
 );

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -16,7 +16,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 mobile:bottom-0 mobile:right-0 mobile:top-auto mobile:flex-col md:max-w-[420px]",
       className,
     )}
     {...props}
@@ -25,7 +25,7 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
-  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:mobile:slide-in-from-bottom-full",
   {
     variants: {
       variant: {

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -124,6 +124,9 @@ const config: Config = {
         },
       },
     },
+    screens: {
+      mobile: "480px",
+    },
   },
   plugins: [require("tailwindcss-animate")],
 };


### PR DESCRIPTION
- when there are not many wallets, we want them to show centered
- when there were too many wallets, the scroll wasn't working
- fixed this with an outer container being scrollable and justify-center, and an inner container with max width

![Screenshot 2024-12-24 at 2.05.44 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/a79a768a-a6f4-45c4-91bb-f79d834e30ef.png)

![Screenshot 2024-12-24 at 2.16.45 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/6d69eb51-b7ed-4188-b69b-d2e54eae2cae.png)

