### PR TITLE
Fix local cookie errors for Safari, show notification payment amount in normal denomination

### DIFF
--- a/backend/vasp/__init__.py
+++ b/backend/vasp/__init__.py
@@ -64,10 +64,10 @@ def create_app() -> Flask:
     cache = Cache(app)
 
     app.secret_key = require_env("FLASK_SECRET_KEY")
-    app.config["REMEMBER_COOKIE_SECURE"] = True
-    app.config["SESSION_COOKIE_SECURE"] = True
-    app.config["SESSION_COOKIE_SAMESITE"] = "None"
-    app.config["REMEMBER_COOKIE_SAMESITE"] = "None"
+    app.config["REMEMBER_COOKIE_SECURE"] = False
+    app.config["SESSION_COOKIE_SECURE"] = False
+    app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+    app.config["REMEMBER_COOKIE_SAMESITE"] = "Lax"
     app.config["REMEMBER_COOKIE_NAME"] = "sandbox_remember_token"
 
     if is_dev:

--- a/backend/vasp/uma_vasp/receiving_vasp.py
+++ b/backend/vasp/uma_vasp/receiving_vasp.py
@@ -698,10 +698,13 @@ def register_routes(
                         receiver_uma=get_uma_from_username(receiver_uma_model.username),
                     )
 
+                    amount_normal_denom = payreq_response.amount_in_lowest_denom / (
+                        10 ** CURRENCIES[payreq_response.currency_code].decimals
+                    )
                     user.send_push_notification(
                         config=config,
-                        title="Payment received",
-                        body=f"Received payment of {-payreq_response.amount_in_lowest_denom} {payreq_response.currency_code}",
+                        title="UMA Sandbox",
+                        body=f"{payreq_response.sender_uma} sent {amount_normal_denom} {payreq_response.currency_code}",
                     )
 
                     logging.info(


### PR DESCRIPTION
Safari doesn't like the cookie headers having secure = True for localhost. Chrome doesn't like samesite = None when secure = False. Changing secure = False and samesite = Lax seems to work for both. 

Updates notification message:

![Screenshot 2025-01-06 at 2.21.43 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/cb596e4a-7f20-405b-aae4-b460e9a53855.png)

