### PR TITLE
Fix ordering of transactions, truncate long umas in transaction history

### DIFF
--- a/backend/vasp/user.py
+++ b/backend/vasp/user.py
@@ -366,6 +366,8 @@ def construct_blueprint(
                 .join(Uma)
                 .where(Transaction.user_id == current_user.id)
                 .where(Uma.username == get_username_from_uma(uma))
+                .order_by(Transaction.created_at.desc())
+                .limit(20)
             ).all()
 
             if not transactions:

--- a/frontend/src/app/wallet/TransactionTable.tsx
+++ b/frontend/src/app/wallet/TransactionTable.tsx
@@ -104,9 +104,9 @@ const TransactionRow = ({
             : undefined
         }
       />
-      <div className="flex flex-col gap-[2px] justify-center grow">
+      <div className="flex flex-col gap-[2px] justify-center grow overflow-hidden">
         <div className="flex flex-row justify-between gap-2">
-          <span className="text-primary text-[15px] font-medium leading-[20px] tracking-[-0.187px]">
+          <span className="text-primary text-[15px] font-medium leading-[20px] tracking-[-0.187px] truncate text-ellipsis">
             {transaction.otherUma}
           </span>
           {amount}


### PR DESCRIPTION
![Screenshot 2025-01-15 at 4.39.16 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/72561ec9-c77c-4855-a94d-132930a43864.png)

- orders to be in descending order
- limits to 20 for now
- truncates long umas so the rows don't grow