### PR TITLE
Allow dismissing pwa install banner

### DIFF
--- a/frontend/src/app/wallet/layout.tsx
+++ b/frontend/src/app/wallet/layout.tsx
@@ -75,7 +75,7 @@ const LayoutContent = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <div className="flex flex-col h-full">
-      <PwaInstallBanner />
+      <PwaInstallBanner dismissable />
       <div className="flex items-center justify-between w-full px-4 py-[3px]">
         {isLoadingWallets || !currentWallet ? (
           <>

--- a/frontend/src/components/PwaInstallBanner.tsx
+++ b/frontend/src/components/PwaInstallBanner.tsx
@@ -3,7 +3,7 @@
 import { usePwaInstallStatus } from "@/hooks/usePwaInstallStatus";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import Image from "next/image";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { SandboxButton } from "./SandboxButton";
 import { Button } from "./ui/button";
 import {
@@ -15,28 +15,67 @@ import {
 
 export const BANNER_HEIGHT = 44;
 
-export const PwaInstallBanner = () => {
+interface Props {
+  dismissable?: boolean;
+}
+
+export const PwaInstallBanner = ({ dismissable }: Props) => {
   const { isInstalled, deviceType } = usePwaInstallStatus();
   const [isInstallScreenOpen, setIsInstallScreenOpen] = useState(false);
+  const [isBannerVisible, setIsBannerVisible] = useState(true);
+
+  useEffect(() => {
+    if (dismissable && localStorage.getItem("pwa-install-banner-dismissed")) {
+      setIsBannerVisible(false);
+    }
+  }, [dismissable]);
+
+  const handleDismissBanner = () => {
+    if (dismissable) {
+      localStorage.setItem("pwa-install-banner-dismissed", "true");
+      setIsBannerVisible(false);
+    }
+  };
+
+  if (dismissable && !isBannerVisible) {
+    return null;
+  }
 
   return (
     <>
       <div
-        className={`p-4 bg-white border-b border-gray-200 flex flex-row items-center justify-between gap-3 mb-[10px] ${
+        className={`p-4 mobile:px-0 mobile:pt-0 bg-white border-b border-gray-200 flex flex-row items-center justify-between gap-3 mb-[10px] ${
           isInstalled || deviceType === "other" ? "hidden" : ""
         }`}
       >
-        <div className="flex flex-row gap-3">
-          <Image
-            src="/uma-sandbox-app.svg"
-            alt="UMA sandbox"
-            width={36}
-            height={36}
-          />
-          <div className="flex flex-col items-start justify-center">
-            <div className="text-gray-800 text-sm">Install the app</div>
-            <div className="text-gray-500 text-xs">
-              Get easy access and notifications
+        <div className="flex flex-row items-center gap-2">
+          {dismissable && (
+            <Button
+              variant="ghost"
+              className="p-0 h-6"
+              onClick={handleDismissBanner}
+            >
+              <Image
+                src="/icons/close-small.svg"
+                alt="close"
+                width={24}
+                height={24}
+                className="opacity-50"
+              />
+            </Button>
+          )}
+          <div className="flex flex-row gap-3">
+            <Image
+              src="/uma-sandbox-app.svg"
+              alt="UMA sandbox"
+              width={36}
+              height={36}
+            />
+            <div className="flex flex-col items-start justify-center">
+              <div className="text-gray-800 text-sm font-semibold">{`It's better on the app`}</div>
+              <div className="text-gray-500 text-xs">
+                Get easy access and notifications
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
![Screenshot 2025-01-23 at 2.28.57 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/6d387c93-3e5e-44f8-bd26-8fc08d798462.png)

when dismissed, state is stored in local storage and it no longer will show the banner until local storage is cleared

it'll still show when onboarding in a logged out state 