### PR TITLE
Fix logged in states after desktop style changes

### DIFF
--- a/frontend/src/app/(onboarding)/Finished.tsx
+++ b/frontend/src/app/(onboarding)/Finished.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { SandboxButton } from "@/components/SandboxButton";
+import { useAppState } from "@/hooks/useAppState";
+import { useWallets } from "@/hooks/useWalletContext";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { StepButtonProps } from "./Steps";
 
 export const Finished = () => {
@@ -30,12 +33,20 @@ export const Finished = () => {
 };
 
 export const FinishedButtons = ({ onNext }: StepButtonProps) => {
+  const router = useRouter();
+  const { fetchWallets } = useWallets();
+  const { setIsLoggedIn } = useAppState();
   return (
     <div className="flex flex-col gap-[10px]">
       <SandboxButton
         buttonProps={{
           size: "lg",
-          onClick: onNext,
+          onClick: () => {
+            fetchWallets();
+            setIsLoggedIn(true);
+            router.push("/wallet");
+            onNext();
+          },
         }}
         className="w-full"
       >

--- a/frontend/src/app/(onboarding)/OnboardingStepContextProvider.tsx
+++ b/frontend/src/app/(onboarding)/OnboardingStepContextProvider.tsx
@@ -107,7 +107,7 @@ function OnboardingStepContextProvider({
   children,
 }: {
   stepOrder: OnboardingStep[];
-  onFinish: () => void;
+  onFinish?: () => void;
   children: React.ReactNode;
 }) {
   const { toast } = useToast();
@@ -136,7 +136,7 @@ function OnboardingStepContextProvider({
             stepNumber: nextStepNumber,
             stepProps: nextStepProps,
           };
-        } else {
+        } else if (onFinish) {
           onFinish();
         }
         return prevData;

--- a/frontend/src/app/(onboarding)/Welcome.tsx
+++ b/frontend/src/app/(onboarding)/Welcome.tsx
@@ -2,6 +2,8 @@
 
 import { SandboxButton } from "@/components/SandboxButton";
 import { useToast } from "@/hooks/use-toast";
+import { useAppState } from "@/hooks/useAppState";
+import { useWallets } from "@/hooks/useWalletContext";
 import { getBackendUrl } from "@/lib/backendUrl";
 import { convertArrayBuffersToBase64 } from "@/lib/convertArrayBuffersToBase64";
 import Image from "next/image";
@@ -37,8 +39,10 @@ export const Welcome = () => {
 
 export const WelcomeButtons = ({ onNext }: StepButtonProps) => {
   const router = useRouter();
+  const { fetchWallets } = useWallets();
   const { toast } = useToast();
   const [isLoadingLogin, setIsLoadingLogin] = useState(false);
+  const { setIsLoggedIn } = useAppState();
 
   const handleLogin = async () => {
     setIsLoadingLogin(true);
@@ -94,6 +98,8 @@ export const WelcomeButtons = ({ onNext }: StepButtonProps) => {
       });
       const loginData = await loginRes.json();
       if (loginData.success) {
+        fetchWallets();
+        setIsLoggedIn(true);
         router.push("/wallet");
       } else {
         toast({

--- a/frontend/src/app/LayoutContent.tsx
+++ b/frontend/src/app/LayoutContent.tsx
@@ -1,9 +1,12 @@
 "use client";
 import { Toaster } from "@/components/ui/toaster";
 import { useMediaQuery } from "@/hooks/use-media-query";
+import { useLoggedIn } from "@/hooks/useLoggedIn";
 import WalletContextProvider from "@/hooks/useWalletContext";
 import { Roboto_Mono } from "next/font/google";
 import localFont from "next/font/local";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 import { PushNotificationManager } from "./PushNotificationManager";
 import { Sidebar } from "./Sidebar";
 
@@ -22,6 +25,14 @@ const roboto_mono = Roboto_Mono({
 
 export const LayoutContent = ({ children }: { children: React.ReactNode }) => {
   const isDesktop = useMediaQuery("(min-width: 800px)");
+  const router = useRouter();
+  const { isLoggedIn } = useLoggedIn();
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      router.push("/wallet");
+    }
+  }, [router, isLoggedIn]);
 
   return (
     <body

--- a/frontend/src/app/Sidebar.tsx
+++ b/frontend/src/app/Sidebar.tsx
@@ -69,13 +69,17 @@ export const Sidebar = () => {
   const { toast } = useToast();
   const router = useRouter();
   const { wallets, error: walletsError } = useWallets();
-  const { currentWallet, setCurrentWallet, setIsCreateUmaDialogOpen } =
-    useAppState();
+  const {
+    currentWallet,
+    setCurrentWallet,
+    setIsCreateUmaDialogOpen,
+    isLoggedIn,
+  } = useAppState();
 
   useEffect(() => {
     if (walletsError) {
       toast({
-        title: `Failed to load wallet layout: ${walletsError}`,
+        title: `Failed to load sidebar: ${walletsError}`,
         variant: "error",
       });
     }
@@ -131,32 +135,34 @@ export const Sidebar = () => {
           </span>
         </div>
         <section className="flex flex-col gap-10">
-          <SidebarSection title="Your test UMAs">
-            {walletButtons}
-            <SandboxButton
-              buttonProps={{
-                variant: "ghost",
-                size: "sidebar",
-                onClick: () => setIsCreateUmaDialogOpen(true),
-              }}
-              className="px-[16px] text-left"
-            >
-              <div className="flex flex-row items-center w-full gap-2">
-                <div className="flex items-center justify-center bg-[#EBEEF2] rounded">
-                  <Image
-                    src="/icons/plus.svg"
-                    alt="Add UMA"
-                    width={24}
-                    height={24}
-                    className="opacity-50"
-                  />
+          {isLoggedIn && (
+            <SidebarSection title="Your test UMAs">
+              {walletButtons}
+              <SandboxButton
+                buttonProps={{
+                  variant: "ghost",
+                  size: "sidebar",
+                  onClick: () => setIsCreateUmaDialogOpen(true),
+                }}
+                className="px-[16px] text-left"
+              >
+                <div className="flex flex-row items-center w-full gap-2">
+                  <div className="flex items-center justify-center bg-[#EBEEF2] rounded">
+                    <Image
+                      src="/icons/plus.svg"
+                      alt="Add UMA"
+                      width={24}
+                      height={24}
+                      className="opacity-50"
+                    />
+                  </div>
+                  <span className="text-[15px] font-semibold leading-[20px] tracking-[-0.187px] text-secondary">
+                    New test UMA
+                  </span>
                 </div>
-                <span className="text-[15px] font-semibold leading-[20px] tracking-[-0.187px] text-secondary">
-                  New test UMA
-                </span>
-              </div>
-            </SandboxButton>
-          </SidebarSection>
+              </SandboxButton>
+            </SidebarSection>
+          )}
           <SidebarSection title="Resources">
             <div className="flex flex-col">
               <ResourceButton
@@ -181,26 +187,28 @@ export const Sidebar = () => {
           </SidebarSection>
         </section>
       </section>
-      <SandboxButton
-        buttonProps={{
-          variant: "ghost",
-          size: "sidebar",
-          onClick: () => router.push("/settings"),
-        }}
-      >
-        <div className="flex flex-row items-center w-full gap-2">
-          <Image
-            src="/icons/settings-gear-2.svg"
-            alt="Settings"
-            width={24}
-            height={24}
-            className="opacity-50"
-          />
-          <span className="text-[15px] font-semibold leading-[20px] tracking-[-0.187px] text-secondary">
-            Account settings
-          </span>
-        </div>
-      </SandboxButton>
+      {isLoggedIn && (
+        <SandboxButton
+          buttonProps={{
+            variant: "ghost",
+            size: "sidebar",
+            onClick: () => router.push("/settings"),
+          }}
+        >
+          <div className="flex flex-row items-center w-full gap-2">
+            <Image
+              src="/icons/settings-gear-2.svg"
+              alt="Settings"
+              width={24}
+              height={24}
+              className="opacity-50"
+            />
+            <span className="text-[15px] font-semibold leading-[20px] tracking-[-0.187px] text-secondary">
+              Account settings
+            </span>
+          </div>
+        </SandboxButton>
+      )}
     </div>
   );
 };

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -2,7 +2,9 @@
 
 import { SandboxButton } from "@/components/SandboxButton";
 import { useToast } from "@/hooks/use-toast";
+import { useAppState } from "@/hooks/useAppState";
 import { useLoggedIn } from "@/hooks/useLoggedIn";
+import { useWallets } from "@/hooks/useWalletContext";
 import { getBackendUrl } from "@/lib/backendUrl";
 import { convertArrayBuffersToBase64 } from "@/lib/convertArrayBuffersToBase64";
 import Image from "next/image";
@@ -11,9 +13,11 @@ import { useEffect, useState } from "react";
 
 export default function Page() {
   const router = useRouter();
+  const { fetchWallets } = useWallets();
   const { toast } = useToast();
   const [isLoadingLogin, setIsLoadingLogin] = useState(false);
   const { isLoggedIn } = useLoggedIn();
+  const { setIsLoggedIn } = useAppState();
 
   useEffect(() => {
     if (isLoggedIn) {
@@ -80,6 +84,8 @@ export default function Page() {
         const [path, redirectUri] = next?.split("?redirect_uri=") || [];
 
         if (!path || !redirectUri) {
+          fetchWallets();
+          setIsLoggedIn(true);
           // Redirect to wallet page if no next query param
           router.push("/wallet");
         } else {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,23 +1,11 @@
 "use client";
 import { PwaInstallBanner } from "@/components/PwaInstallBanner";
-import { useLoggedIn } from "@/hooks/useLoggedIn";
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
 import OnboardingStepContextProvider, {
   OnboardingStep,
 } from "./(onboarding)/OnboardingStepContextProvider";
 import { Steps } from "./(onboarding)/Steps";
 
 export default function Home() {
-  const router = useRouter();
-  const { isLoggedIn } = useLoggedIn();
-
-  useEffect(() => {
-    if (isLoggedIn) {
-      router.push("/wallet");
-    }
-  }, [router, isLoggedIn]);
-
   return (
     <div className="flex flex-col h-full items-center justify-center">
       <PwaInstallBanner />
@@ -31,7 +19,6 @@ export default function Home() {
           OnboardingStep.EnableNotifications,
           OnboardingStep.Finished,
         ]}
-        onFinish={() => router.push("/wallet")}
       >
         <Steps showHeader />
       </OnboardingStepContextProvider>

--- a/frontend/src/app/send/layout.tsx
+++ b/frontend/src/app/send/layout.tsx
@@ -2,24 +2,13 @@
 
 import { CreateUmaDialog } from "@/components/CreateUmaDialog";
 import { useAppState } from "@/hooks/useAppState";
-import UmaContextProvider from "@/hooks/useUmaContext";
-import WalletContextProvider, { useWallets } from "@/hooks/useWalletContext";
+import { useWallets } from "@/hooks/useWalletContext";
 import { getUmaFromUsername } from "@/lib/uma";
 import React from "react";
 import { Header } from "./Header";
 import SendPaymentContextProvider from "./SendPaymentContextProvider";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return (
-    <UmaContextProvider>
-      <WalletContextProvider>
-        <LayoutContent>{children}</LayoutContent>
-      </WalletContextProvider>
-    </UmaContextProvider>
-  );
-}
-
-const LayoutContent = ({ children }: { children: React.ReactNode }) => {
   const {
     isLoading: isLoadingWallets,
     error: walletError,
@@ -47,4 +36,4 @@ const LayoutContent = ({ children }: { children: React.ReactNode }) => {
       )}
     </div>
   );
-};
+}

--- a/frontend/src/app/uma-settings/layout.tsx
+++ b/frontend/src/app/uma-settings/layout.tsx
@@ -1,15 +1,10 @@
 "use client";
 
-import WalletContextProvider from "@/hooks/useWalletContext";
 import React from "react";
 import { Header } from "./Header";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return (
-    <WalletContextProvider>
-      <LayoutContent>{children}</LayoutContent>
-    </WalletContextProvider>
-  );
+  return <LayoutContent>{children}</LayoutContent>;
 }
 
 function LayoutContent({ children }: { children: React.ReactNode }) {

--- a/frontend/src/app/uma-settings/page.tsx
+++ b/frontend/src/app/uma-settings/page.tsx
@@ -33,7 +33,7 @@ export default function Page() {
             ? wallets.filter((wallet) => wallet.id !== currentWallet.id)[0]
             : undefined,
         );
-        router.push("/");
+        router.push("/wallet");
       } catch (e) {
         toast({
           title: `Failed to delete uma: ${e}`,

--- a/frontend/src/app/wallet/layout.tsx
+++ b/frontend/src/app/wallet/layout.tsx
@@ -8,8 +8,7 @@ import { UmaSwitcherFooter } from "@/components/UmaSwitcherFooter";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { useToast } from "@/hooks/use-toast";
 import { useAppState } from "@/hooks/useAppState";
-import UmaContextProvider from "@/hooks/useUmaContext";
-import WalletContextProvider, { useWallets } from "@/hooks/useWalletContext";
+import { useWallets } from "@/hooks/useWalletContext";
 import { getUmaFromUsername } from "@/lib/uma";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
@@ -17,16 +16,6 @@ import { useEffect } from "react";
 import { UmaSelectorDialog } from "./UmaSelectorDialog";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  return (
-    <UmaContextProvider>
-      <WalletContextProvider>
-        <LayoutContent>{children}</LayoutContent>
-      </WalletContextProvider>
-    </UmaContextProvider>
-  );
-}
-
-const LayoutContent = ({ children }: { children: React.ReactNode }) => {
   const isDesktop = useMediaQuery("(min-width: 800px)");
   const { toast } = useToast();
   const router = useRouter();
@@ -172,4 +161,4 @@ const LayoutContent = ({ children }: { children: React.ReactNode }) => {
       )}
     </div>
   );
-};
+}

--- a/frontend/src/hooks/useAppState.tsx
+++ b/frontend/src/hooks/useAppState.tsx
@@ -4,7 +4,9 @@ import { Wallet } from "./useWalletContext";
 interface AppState {
   isUmaSelectorDialogOpen: boolean;
   isCreateUmaDialogOpen: boolean;
+  isLoggedIn: boolean;
   currentWallet?: Wallet | undefined;
+  setIsLoggedIn: (isLoggedIn: boolean) => void;
   setCurrentWallet: (wallet: Wallet | undefined) => void;
   resetAppState: () => void;
   setIsUmaSelectorDialogOpen: (isOpen: boolean) => void;
@@ -12,11 +14,14 @@ interface AppState {
 }
 
 export const useAppState = create<AppState>((set) => ({
+  isLoggedIn: false,
   isUmaSelectorDialogOpen: false,
   isCreateUmaDialogOpen: false,
+  setIsLoggedIn: (isLoggedIn) => set({ isLoggedIn }),
   setCurrentWallet: (wallet) => set({ currentWallet: wallet }),
   resetAppState: () =>
     set({
+      isLoggedIn: false,
       currentWallet: undefined,
       isUmaSelectorDialogOpen: false,
       isCreateUmaDialogOpen: false,

--- a/frontend/src/hooks/useLoggedIn.tsx
+++ b/frontend/src/hooks/useLoggedIn.tsx
@@ -1,5 +1,6 @@
 import { getBackendUrl } from "@/lib/backendUrl";
 import { useEffect, useState } from "react";
+import { useAppState } from "./useAppState";
 
 export interface RawLoggedIn {
   logged_in: boolean;
@@ -10,6 +11,7 @@ export interface LoggedIn {
 }
 
 export const useLoggedIn = () => {
+  const { setIsLoggedIn: setAppStateIsLoggedIn } = useAppState();
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>();
   const [error, setError] = useState<string>();
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -30,6 +32,7 @@ export const useLoggedIn = () => {
         });
         if (!ignore) {
           setIsLoggedIn(response.logged_in);
+          setAppStateIsLoggedIn(response.logged_in);
           setIsLoading(false);
         }
       } catch (e: unknown) {
@@ -44,7 +47,7 @@ export const useLoggedIn = () => {
     return () => {
       ignore = true;
     };
-  }, []);
+  }, [setAppStateIsLoggedIn]);
 
   return {
     isLoggedIn,

--- a/frontend/src/hooks/useWalletContext.tsx
+++ b/frontend/src/hooks/useWalletContext.tsx
@@ -55,20 +55,25 @@ export const fetchWallets = async (): Promise<Wallet[]> => {
     credentials: "include",
   });
   if (res.ok) {
-    const { wallets } = await (res.json() as Promise<{ wallets: RawWallet[] }>);
-    return wallets.map((rawWallet) => ({
-      id: rawWallet.id,
-      amountInLowestDenom: rawWallet.amount_in_lowest_denom,
-      color: RAW_WALLET_COLOR_MAPPING[rawWallet.color],
-      deviceToken: rawWallet.device_token,
-      name: rawWallet.name,
-      uma: {
-        userId: rawWallet.uma.user_id,
-        username: rawWallet.uma.username,
-        default: rawWallet.uma.default,
-      },
-      currency: rawWallet.currency,
-    }));
+    const { wallets } = await (res.json() as Promise<{
+      wallets?: RawWallet[];
+    }>);
+
+    return (
+      wallets?.map((rawWallet) => ({
+        id: rawWallet.id,
+        amountInLowestDenom: rawWallet.amount_in_lowest_denom,
+        color: RAW_WALLET_COLOR_MAPPING[rawWallet.color],
+        deviceToken: rawWallet.device_token,
+        name: rawWallet.name,
+        uma: {
+          userId: rawWallet.uma.user_id,
+          username: rawWallet.uma.username,
+          default: rawWallet.uma.default,
+        },
+        currency: rawWallet.currency,
+      })) || []
+    );
   } else {
     throw new Error("Failed to fetch wallets.");
   }


### PR DESCRIPTION
The previous change moved the wallet context up to the top-most layout, so we need to make sure to refetch the wallets upon logging in and keep track of logged in state so the sidebar knows when to display certain buttons.