### PR TITLE
Use SameSite=None cookies instead of domains

### DIFF
--- a/backend/vasp/__init__.py
+++ b/backend/vasp/__init__.py
@@ -64,16 +64,13 @@ def create_app() -> Flask:
     cache = Cache(app)
 
     app.secret_key = require_env("FLASK_SECRET_KEY")
-    app.config["REMEMBER_COOKIE_SECURE"] = False
-    app.config["SESSION_COOKIE_SECURE"] = False
-    app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
-    app.config["REMEMBER_COOKIE_SAMESITE"] = "Lax"
+    app.config["REMEMBER_COOKIE_SECURE"] = True
+    app.config["SESSION_COOKIE_SECURE"] = True
+    app.config["SESSION_COOKIE_SAMESITE"] = "None"
+    app.config["REMEMBER_COOKIE_SAMESITE"] = "None"
     app.config["REMEMBER_COOKIE_NAME"] = "sandbox_remember_token"
 
     config = Config.get()
-
-    app.config["SESSION_COOKIE_DOMAIN"] = app.config["COOKIE_DOMAIN"]
-    app.config["REMEMBER_COOKIE_DOMAIN"] = app.config["COOKIE_DOMAIN"]
 
     login_manager = LoginManager()
     login_manager.init_app(app)


### PR DESCRIPTION
Explicit cookie domains should generally be avoided, and this is an issue for development deployment with the frontend in Vercel. Switch to using `SameSite=None` instead.