### PR TITLE
[frontend] don't subscribe to push notifications if permissions are not yet granted

### DIFF
--- a/frontend/src/app/PushNotificationManager.tsx
+++ b/frontend/src/app/PushNotificationManager.tsx
@@ -15,6 +15,7 @@ export function PushNotificationManager() {
           return;
         } else if (Notification.permission === "default") {
           console.log("Has not requested permission for push notifications");
+          return;
         }
 
         try {


### PR DESCRIPTION
Safari throws an error when trying to subscribe to push notifications when the user has not made an action. Make sure PushNotificationManager doesn't prompt until the user has specifically granted permission