### PR TITLE
[frontend] add ios pwa install banner back, add bottom padding when installed for ios

### DIFF
--- a/frontend/src/app/LayoutContent.tsx
+++ b/frontend/src/app/LayoutContent.tsx
@@ -2,6 +2,7 @@
 import { Toaster } from "@/components/ui/toaster";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { useLoggedIn } from "@/hooks/useLoggedIn";
+import { usePwaInstallStatus } from "@/hooks/usePwaInstallStatus";
 import WalletContextProvider from "@/hooks/useWalletContext";
 import { Roboto_Mono } from "next/font/google";
 import localFont from "next/font/local";
@@ -26,6 +27,7 @@ const roboto_mono = Roboto_Mono({
 export const LayoutContent = ({ children }: { children: React.ReactNode }) => {
   const isDesktop = useMediaQuery("(min-width: 800px)");
   const router = useRouter();
+  const { isInstalled, deviceType } = usePwaInstallStatus();
   const { isLoggedIn } = useLoggedIn();
 
   useEffect(() => {
@@ -43,7 +45,11 @@ export const LayoutContent = ({ children }: { children: React.ReactNode }) => {
         <div className="w-full h-dvh flex flex-row">
           {isDesktop && <Sidebar />}
           <section className="w-full flex grow items-center justify-center">
-            <div className="max-w-[432px] min-w-[300px] w-full h-dvh mobile:max-h-[916px] mobile:border-[0.5px] border-[#EBEEF2] mobile:rounded-[32px] mobile:px-4 mobile:pt-6 bg-white">
+            <div
+              className={`max-w-[432px] min-w-[300px] w-full h-dvh mobile:max-h-[916px] mobile:border-[0.5px] border-[#EBEEF2] mobile:rounded-[32px] mobile:px-4 mobile:pt-6 bg-white ${
+                isInstalled && deviceType === "ios" ? "pb-8" : ""
+              }`}
+            >
               {children}
               <Toaster />
             </div>

--- a/frontend/src/components/PwaInstallBanner.tsx
+++ b/frontend/src/components/PwaInstallBanner.tsx
@@ -41,8 +41,8 @@ export const PwaInstallBanner = ({ dismissable }: Props) => {
     return null;
   }
 
-  // TODO: session cookies are not being persisted in iOS PWAs, only show the banner on android for now
-  const shouldShowBanner = !isInstalled && deviceType === "android";
+  const shouldShowBanner =
+    !isInstalled && ["ios", "android"].includes(deviceType);
 
   return (
     <>


### PR DESCRIPTION
- seems like ios pwa was blocking 3rd party cookies, but it works now that we aren't using 3rd party cookies
- adds bottom padding for ios pwa because buttons are too low on the screen

![Screenshot 2025-03-14 at 2.34.38 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/0bfdef1b-566a-4a7f-a2fd-2a8591d4cdf3.png)

