### PR TITLE
[backend] update cookies to use Partitioned in prod

### DIFF
--- a/backend/vasp/__init__.py
+++ b/backend/vasp/__init__.py
@@ -65,6 +65,8 @@ def create_app() -> Flask:
     app.secret_key = require_env("FLASK_SECRET_KEY")
     app.config["REMEMBER_COOKIE_SECURE"] = False if is_dev else True
     app.config["SESSION_COOKIE_SECURE"] = False if is_dev else True
+    app.config["REMEMBER_COOKIE_PARTITIONED"] = False if is_dev else True
+    app.config["SESSION_COOKIE_PARTITIONED"] = False if is_dev else True
     app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
     app.config["REMEMBER_COOKIE_SAMESITE"] = "Lax"
     app.config["REMEMBER_COOKIE_NAME"] = "test_wallet_remember_token"


### PR DESCRIPTION
When uma authing in playground, this app is iframed and thus cookies are not currently allowed to be set. 

![Screenshot 2025-03-31 at 12.12.01 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/NU8OmLauzLqa61yWDJkY/f25d7c0d-ade9-42b0-b4d8-6cbdb9a78a19.png)

This doesn't have support in safari and firefox though but testing to see if this will work