### PR TITLE
feat: updating test wallet to also return nationality as LSP requires it

### DIFF
--- a/backend/vasp/uma_vasp/receiving_vasp.py
+++ b/backend/vasp/uma_vasp/receiving_vasp.py
@@ -289,6 +289,11 @@ class ReceivingVasp:
                     if user.country_of_residence
                     else {}
                 ),
+                **(
+                    {"nationality": user.country_of_residence}
+                    if user.country_of_residence
+                    else {}
+                ),
                 **({"birthDate": user.birthday.isoformat()} if user.birthday else {}),
             },
         )


### PR DESCRIPTION
### TL;DR

Added nationality field to the beneficiary data in the pay request callback.

### What changed?

Added the nationality field to the beneficiary data in the `handle_pay_request_callback` method of the receiving VASP. The nationality is set to the user's country of residence if it exists.

### How to test?

1. Set up a user with a country of residence
2. Trigger a pay request callback for this user
3. Verify that the beneficiary data in the response includes the nationality field with the value matching the user's country of residence

### Why make this change?

This change ensures that the nationality information is properly included in the beneficiary data sent during payment requests, which may be required for compliance with certain regulatory requirements or to provide more complete user information to receiving VASPs.