### PR TITLE
feat:adding userType INDIVIDUAL to users

### DIFF
--- a/backend/vasp/uma_vasp/receiving_vasp.py
+++ b/backend/vasp/uma_vasp/receiving_vasp.py
@@ -284,6 +284,7 @@ class ReceivingVasp:
                 "identifier": receiver_uma,
                 "name": user.full_name,
                 "email": user.email_address,
+                "userType": "INDIVIDUAL",
                 **(
                     {"countryOfResidence": user.country_of_residence}
                     if user.country_of_residence


### PR DESCRIPTION
### TL;DR

Added `userType` field to the receiver information in the pay request callback.

### What changed?

Added a new field `userType` with the value `"INDIVIDUAL"` to the receiver information dictionary in the `handle_pay_request_callback` method of the receiving VASP implementation.

